### PR TITLE
Make widgets inherit name from parent

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -772,7 +772,7 @@ end
 
 ---The name that is displayed on pragtical tabs.
 function Widget:get_name()
-  return self.name
+  return self.parent and self.parent:get_name() or self.name
 end
 
 --


### PR DESCRIPTION
This PR gives new Widgets the same name as their parent and fall back to the application name if no parent was given.

This could also be done at runtime by changing `get_name()` which would allow changes in the parent's name to propagate down. Should we do that?

