### PR TITLE
Use capital W when checking if font is monospaced

### DIFF
--- a/fonts/info.lua
+++ b/fonts/info.lua
@@ -354,7 +354,7 @@ function FontInfo.check_is_monospace(font_data)
     if not loaded then
       return false, "could not load font"
     else
-      if fontren:get_width("|") == fontren:get_width("w") then
+      if fontren:get_width("|") == fontren:get_width("W") then
         font_data.monospace = true
       else
         font_data.monospace = false


### PR DESCRIPTION
This change gives a better chance of properly detecting if a font is monospaced due to changes on pragtical/pragtical#122